### PR TITLE
Fix case sensitivity in upgrade socket request.

### DIFF
--- a/src/PHPSocketIO/Http/WebSocket/WebSocket.php
+++ b/src/PHPSocketIO/Http/WebSocket/WebSocket.php
@@ -35,7 +35,7 @@ class WebSocket
     {
         $key = $request->headers->get('Sec-WebSocket-Key');
         if(
-                $request->headers->get('Upgrade') != 'websocket' ||
+                strtolower($request->headers->get('Upgrade')) != 'websocket' ||
                 !$this->checkProtocolVrsion($request) ||
                 !$this->checkSecKey($key)
           ){


### PR DESCRIPTION
If server-script recieve any variations like 'WebSocket' instead of 'websocket' then will return 'Bad request'. This problem finded after try to connect with ElephantSocketIO library client to your PHPSocketIO server.
