### PR TITLE
Limit dependency version to 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "symfony/http-foundation":  ">=2.2",
-        "symfony/event-dispatcher": ">=2.3"
+        "symfony/event-dispatcher": "2.3"
     },
     "suggest": {
         "ext-event": "1.8.1"


### PR DESCRIPTION
Changed "symfony/event-dispatcher": "2.3" as many function of EventDispatcher are deprecated in version 2.4
